### PR TITLE
fix: Add base_url to ChatOpenAI to respect OPENAI_API_BASE_URL setting

### DIFF
--- a/pipelines/chat-with-youtube-openai-pipeline.py
+++ b/pipelines/chat-with-youtube-openai-pipeline.py
@@ -88,6 +88,7 @@ class Pipeline:
     def pipe(self, user_message: str, model_id: str, messages: List[dict], body: dict):
         try:
             model = ChatOpenAI(
+                base_url=self.valves.OPENAI_API_BASE_URL,
                 api_key=self.valves.OPENAI_API_KEY,
                 model=self.valves.OPENAI_API_MODEL,
                 temperature=self.valves.OPENAI_API_TEMPERATURE


### PR DESCRIPTION
# Add support for custom OpenAI API endpoints

## Description
This PR fixes a bug where the `OPENAI_API_BASE_URL` configuration was not being passed to the `ChatOpenAI` client. As a result, users couldn't connect to custom OpenAI-compatible endpoints or proxies.

## Changes
- Added the `base_url` parameter to the `ChatOpenAI` initialization
- The system now correctly uses the configured API endpoint from `OPENAI_API_BASE_URL`

## Testing
Verified that the application can successfully:
- Connect to the default OpenAI API when no custom URL is provided
- Connect to custom OpenAI-compatible endpoints when `OPENAI_API_BASE_URL` is set

## Additional Notes
This change is particularly useful for users who:
- Need to use OpenAI-compatible APIs in regions with limited access
- Run local models with OpenAI-compatible interfaces (like LM Studio)
- Use proxy services to access OpenAI APIs